### PR TITLE
Polish cursor

### DIFF
--- a/nova.handlebars
+++ b/nova.handlebars
@@ -41,7 +41,7 @@
     <key>Bold Color</key>
     {{> color of=bright.white}}
     <key>Cursor Color</key>
-    {{> color of=bright.white}}
+    {{> color of=decoration.dark}}
     <key>Cursor Guide Color</key>
     {{> color of=bright.white}}
     <key>Cursor Text Color</key>

--- a/nova.itermcolors
+++ b/nova.itermcolors
@@ -216,11 +216,11 @@
       <key>Color Space</key>
       <string>sRGB</string>
       <key>Blue Component</key>
-      <real>0.9529411764705882</real>
+      <real>0.17254901960784313</real>
       <key>Green Component</key>
-      <real>0.9333333333333333</real>
+      <real>0.15294117647058825</real>
       <key>Red Component</key>
-      <real>0.9019607843137255</real>
+      <real>0.11764705882352941</real>
     </dict>
     <key>Cursor Guide Color</key>
     <dict>


### PR DESCRIPTION
@iammerrick

Update to dark cursor to match latest nova-hyperterm. I feel like it adds some nice contrast with the bright colors beneath whereas the bright.white from before was hard for me to find.

### HyperTerm:
![screen shot 2016-09-06 at 4 05 59 pm](https://cloud.githubusercontent.com/assets/5497885/18292894/02599862-744d-11e6-9486-9538fdeea08d.png)
https://github.com/trevordmiller/nova-hyperterm/commit/531f9ee4e2f1104d10a3e57c69a48962d12b1019

### iTerm:
![screen shot 2016-09-06 at 4 13 06 pm](https://cloud.githubusercontent.com/assets/5497885/18292893/0256c7e0-744d-11e6-9d3b-65a3345b5fd1.png)
Doesn't look as good as the HyperTerm version (seems that iTerm uses a difference algorithm for the underlying text instead of overall opacity). But still better than white IMO. What do you think?
